### PR TITLE
Remove unnecessary --add-exports  options to specify internal classes

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -96,17 +96,6 @@ def pretty_format_java(argv: typing.Optional[typing.List[str]] = None) -> int:
 
     cmd_args = [
         "java",
-        # export JDK internal classes for Java 16+
-        "--add-exports",
-        "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        "--add-exports",
-        "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-        "--add-exports",
-        "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-        "--add-exports",
-        "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports",
-        "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
         "-jar",
         google_java_formatter_jar,
         "--set-exit-if-changed",


### PR DESCRIPTION
# Background

google-java-format supports --add-exports out of box since v1.15.0. Therefore, pretty_format_java.py no longer need to specify the internal classes.

# Note

`pretty_format_java.py` is missing

```
--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
```

that is necessary for JDK 17 and newer. google-java-format will support the option out of box and we should not pass the options in pretty_format_java.py.

# Reference

- https://github.com/google/google-java-format/releases/tag/v1.15.0